### PR TITLE
Remove HotModuleReplacementPlugin

### DIFF
--- a/webpack/development.js
+++ b/webpack/development.js
@@ -58,7 +58,6 @@ module.exports = merge(baseConfig, {
   },
 
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
     new MiniCssExtractPlugin({
       filename: '[name].css',
       chunkFilename: '[id].css'


### PR DESCRIPTION
Remove HotModuleReplacementPlugin from webpack since it's already used on the script command